### PR TITLE
Set sunrise/sunset to local time on phone; make switching to imperial units more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Build/Installation
 - Setup Pebble SDK 3.0
-- run 'peble build'
+- Edit src/weather.js and add your openweathermap API key
+- run 'pebble build'
 - copy build/pebble-binary-basic.pbw to phone
 - Open pebble-binary-basic.pbw on phone; Pebble app will ask you to install to watch
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # pebble-binary-basic
+
+Build/Installation
+- Setup Pebble SDK 3.0
+- run 'peble build'
+- copy build/pebble-binary-basic.pbw to phone
+- Open pebble-binary-basic.pbw on phone; Pebble app will ask you to install to watch
+
+Usage
+
+Usage of the app is pretty straight forward. Each column encodes "binary coded decimal" to show the 4 digits of the time, where a black shaded box represents a 1 and a white shaded box represents a 0. Inside each square is (From left to right starting at the top) Wind Speed, Barometric Pressure, Relative Humidity, Minutes since last weather update, Sunrise, Sunset, current conditions graphic (sunny, rainy, cloudy, etc), temperature, Day of Week, Month of Year, Day of Month, Seconds
+
+There is currently no configuration settings. To change from Metric to Imperial units, edit weather.js and main.c accordingly.

--- a/appinfo.json
+++ b/appinfo.json
@@ -36,6 +36,7 @@
     ],
     "uuid": "5712b313-8c61-43b6-a8cb-157c5d323a9d",
     "versionLabel": "0.1",
+    "versionCode": 1,
     "watchapp": {
         "watchface": true
     }

--- a/appinfo.json
+++ b/appinfo.json
@@ -1,13 +1,13 @@
 {
     "appKeys": {
-        "KEY_CONDITIONS": 1,
-        "KEY_CONDITIONS_ID": 9,
-        "KEY_HUMIDITY": 8,
-        "KEY_PRESSURE": 7,
-        "KEY_SUNRISE": 4,
-        "KEY_SUNSET": 5,
         "KEY_TEMPERATURE": 0,
-        "KEY_WIND": 6
+        "KEY_CONDITIONS": 1,
+        "KEY_SUNRISE": 2,
+        "KEY_SUNSET": 3,
+        "KEY_WIND": 4,
+        "KEY_PRESSURE": 5,
+        "KEY_HUMIDITY": 6,
+        "KEY_CONDITIONS_ID": 7
     },
     "capabilities": [
         "location"

--- a/src/main.c
+++ b/src/main.c
@@ -11,8 +11,8 @@ enum appKeys {
     KEY_CONDITIONS_ID,
 };
 
-static const float hpa_hg = 1.3332239; //mmhq
-//static const float hpa_hg = 33.86; //inhq
+//static const float hpa_hg = 1.3332239; //mmhq
+static const float hpa_hg = 33.86; //inhq
 
 static const char *day_of_week_2ch[7] = {"su", "mo","tu","we", "th", "fr", "sa"};
 static const char *month_of_year_2ch[12] = {"ja", "fe", "mr", "ap", "my", "jn", \
@@ -205,7 +205,7 @@ static void set_s_weekday_buffer(int weekday) {
 static void set_s_temperature_buffer () {
   if (conditions_updated == true) {
     if (canvas_count_ox <= 5) {
-      snprintf(s_temperature_buffer, sizeof(s_temperature_buffer), "%02dc", temperature_degrees);
+      snprintf(s_temperature_buffer, sizeof(s_temperature_buffer), "%02df", temperature_degrees);
     } else {
       snprintf(s_temperature_buffer, sizeof(s_temperature_buffer), "%02d", temperature_degrees);
     }
@@ -217,7 +217,7 @@ static void set_s_temperature_buffer () {
 static void set_s_wind_buffer () {
     if (conditions_updated == true) {
       if (canvas_count_ox <= 5) {
-        snprintf(s_wind_buffer, sizeof(s_wind_buffer), "%dkh", wind);
+        snprintf(s_wind_buffer, sizeof(s_wind_buffer), "%dmi", wind);
       } else {
         snprintf(s_wind_buffer, sizeof(s_wind_buffer), "%d", wind);
       }

--- a/src/main.c
+++ b/src/main.c
@@ -1,9 +1,9 @@
 #include <pebble.h>
    
-enum KEYS {
+enum appKeys {
     KEY_TEMPERATURE,
     KEY_CONDITIONS,
-    KEY_SUNRISE = 4,
+    KEY_SUNRISE,
     KEY_SUNSET,
     KEY_WIND,
     KEY_PRESSURE,

--- a/src/main.c
+++ b/src/main.c
@@ -1,15 +1,18 @@
 #include <pebble.h>
-    
-#define KEY_TEMPERATURE 0
-#define KEY_CONDITIONS 1
-#define KEY_SUNRISE 4
-#define KEY_SUNSET 5
-#define KEY_WIND 6
-#define KEY_PRESSURE 7
-#define KEY_HUMIDITY 8
-#define KEY_CONDITIONS_ID 9
+   
+enum KEYS {
+    KEY_TEMPERATURE,
+    KEY_CONDITIONS,
+    KEY_SUNRISE = 4,
+    KEY_SUNSET,
+    KEY_WIND,
+    KEY_PRESSURE,
+    KEY_HUMIDITY,
+    KEY_CONDITIONS_ID,
+}
 
-static const float hpa_mmhg = 1.3332239;
+static const float hpa_hg = 1.3332239; //mmhq
+//static const float hpa_hg = 33.86; //inhq
 
 static const char *day_of_week_2ch[7] = {"su", "mo","tu","we", "th", "fr", "sa"};
 static const char *month_of_year_2ch[12] = {"ja", "fe", "mr", "ap", "my", "jn", \
@@ -70,7 +73,6 @@ static short int
           canvas_font_digits_height_px, \
           canvas_font_icons_height_px, \
           temperature_degrees, conditions_id, \
-          time_zone, daylight_savings, \
           wind, pressure, humidity, refreshed_minutes_ago;
 
 static long int sunrise_epoch, sunset_epoch;
@@ -162,8 +164,6 @@ static void init_settings() {
     minutes_1stdigit_max_cols = 4;
     seconds_1stdigit_max_cols = 4;
 
-    time_zone = +2;
-    daylight_savings = 1;
     refreshed_minutes_ago = 0;
 
     if (canvas_count_ox <= 4) {
@@ -297,10 +297,10 @@ static void set_sunset_sunrise_time () {
 
   struct tm *t;
   t = localtime(&sunrise_epoch);
-  short int sunrise_hour = t->tm_hour + time_zone + daylight_savings;
+  short int sunrise_hour = t->tm_hour;
   short int sunrise_minutes = t->tm_min;
   t = localtime(&sunset_epoch);
-  short int sunset_hour = t->tm_hour + time_zone + daylight_savings;
+  short int sunset_hour = t->tm_hour;
   short int sunset_minutes = t->tm_min;
   
   if (canvas_count_ox <= 4) {
@@ -628,7 +628,7 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
       wind = (int)t->value->int32;
       break;
     case KEY_PRESSURE:
-      pressure = (int)t->value->int32/hpa_mmhg;
+      pressure = (int)t->value->int32/hpa_hg;
       break;
     case KEY_HUMIDITY:
       humidity = (int)t->value->int32;

--- a/src/main.c
+++ b/src/main.c
@@ -9,7 +9,7 @@ enum appKeys {
     KEY_PRESSURE,
     KEY_HUMIDITY,
     KEY_CONDITIONS_ID,
-}
+};
 
 static const float hpa_hg = 1.3332239; //mmhq
 //static const float hpa_hg = 33.86; //inhq

--- a/src/weather.js
+++ b/src/weather.js
@@ -15,12 +15,13 @@ function getTimezoneOffsetSec() {
 
 function locationSuccess(pos) {
   var latitude = String(pos.coords.latitude);
-  var longitude = String(pos.coords.longitude); 
+  var longitude = String(pos.coords.longitude);
+  var apikey = "REDACTED";
   var secToGmt = getTimezoneOffsetSec();
 
   //For Farhenheit, change "metric" to "imperial".
   var url = "http://api.openweathermap.org/data/2.5/weather?units=imperial&lat=" +
-      latitude + "&lon=" + longitude;
+      latitude + "&lon=" + longitude + "&appid=" + apikey;
       console.log("URL:" + url);
 
   xhrRequest(url, 'GET', 

--- a/src/weather.js
+++ b/src/weather.js
@@ -7,7 +7,7 @@ var xhrRequest = function (url, type, callback) {
   xhr.send();
 };
 
-function getTimezoneOffset() {
+function getTimezoneOffsetSec() {
   //see http://developer.getpebble.com/blog/2013/12/20/Pebble-Javascript-Tips-and-Tricks/
   var offsetSeconds = new Date().getTimezoneOffset() * 60;
   return offsetSeconds;
@@ -16,7 +16,7 @@ function getTimezoneOffset() {
 function locationSuccess(pos) {
   var latitude = String(pos.coords.latitude);
   var longitude = String(pos.coords.longitude); 
-  var sec_to_gmt = getTimezoneOffset();
+  var secToGmt = getTimezoneOffsetSec();
 
   //For Farhenheit, change "metric" to "imperial".
   var url = "http://api.openweathermap.org/data/2.5/weather?units=metric&lat=" +
@@ -29,8 +29,8 @@ function locationSuccess(pos) {
      var temperature = Math.round(json.main.temp);
      var conditions = json.weather[0].main;  
      var conditions_id = json.weather[0].id;
-     var sunrise = json.sys.sunrise - sec_to_gmt;
-     var sunset = json.sys.sunset - sec_to_gmt;
+     var sunrise = json.sys.sunrise - secToGmt;
+     var sunset = json.sys.sunset - secToGmt;
      var wind = Math.round(json.wind.speed);
      var pressure = Math.round(json.main.pressure);
      var humidity = Math.round(json.main.humidity);

--- a/src/weather.js
+++ b/src/weather.js
@@ -19,7 +19,7 @@ function locationSuccess(pos) {
   var secToGmt = getTimezoneOffsetSec();
 
   //For Farhenheit, change "metric" to "imperial".
-  var url = "http://api.openweathermap.org/data/2.5/weather?units=metric&lat=" +
+  var url = "http://api.openweathermap.org/data/2.5/weather?units=imperial&lat=" +
       latitude + "&lon=" + longitude;
       console.log("URL:" + url);
 

--- a/src/weather.js
+++ b/src/weather.js
@@ -7,22 +7,30 @@ var xhrRequest = function (url, type, callback) {
   xhr.send();
 };
 
+function getTimezoneOffset() {
+  //see http://developer.getpebble.com/blog/2013/12/20/Pebble-Javascript-Tips-and-Tricks/
+  var offsetSeconds = new Date().getTimezoneOffset() * 60;
+  return offsetSeconds;
+}
+
 function locationSuccess(pos) {
   var latitude = String(pos.coords.latitude);
   var longitude = String(pos.coords.longitude); 
+  var sec_to_gmt = getTimezoneOffset();
 
-  var url = "http://api.openweathermap.org/data/2.5/weather?lat=" +
+  //For Farhenheit, change "metric" to "imperial".
+  var url = "http://api.openweathermap.org/data/2.5/weather?units=metric&lat=" +
       latitude + "&lon=" + longitude;
       console.log("URL:" + url);
 
   xhrRequest(url, 'GET', 
     function(responseText) {
      var json = JSON.parse(responseText);
-     var temperature = Math.round(json.main.temp - 273.15);
+     var temperature = Math.round(json.main.temp);
      var conditions = json.weather[0].main;  
      var conditions_id = json.weather[0].id;
-     var sunrise = json.sys.sunrise;
-     var sunset = json.sys.sunset;
+     var sunrise = json.sys.sunrise - sec_to_gmt;
+     var sunset = json.sys.sunset - sec_to_gmt;
      var wind = Math.round(json.wind.speed);
      var pressure = Math.round(json.main.pressure);
      var humidity = Math.round(json.main.humidity);


### PR DESCRIPTION
These commits convert the sunrise/sunset to the local timezone (and daylights savings time) of the phone so you don't need to hard code them.

Since I prefer imperial units to metric, I also made it easy for me (and other users) to switch between metric and imperial units.
